### PR TITLE
[기능] 메인보드 ui 분리 및 터미널 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "core-js": "^3.29.0",
     "roboto-fontface": "*",
     "vue": "^3.2.0",
+    "vue-command": "^35.1.0",
     "vue-router": "^4.0.0",
     "vuetify": "^3.0.0",
     "webfontloader": "^1.0.0"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,8 @@
 <script setup>
 import AppBar from './layouts/default/AppBar.vue'
 import LeftDrawer from './layouts/default/LeftDrawer.vue'
-
+import MainTop from './components/MainTop.vue'
+import MainBottom from './components/MainBottom.vue'
 import NodePlane from './components/NodePlane.vue'
 </script>
 
@@ -10,7 +11,10 @@ import NodePlane from './components/NodePlane.vue'
     <AppBar />
     <LeftDrawer />
     <v-main>
-      <NodePlane />
+      <v-container fluid class="fill-height">
+        <MainTop />
+        <NodePlane />
+      </v-container>
     </v-main>
   </v-app>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,10 +11,21 @@ import NodePlane from './components/NodePlane.vue'
     <AppBar />
     <LeftDrawer />
     <v-main>
-      <v-container fluid class="fill-height">
-        <MainTop />
-        <NodePlane />
+      <v-container fluid class="container-size">
+        <v-row>
+          <v-col><MainTop /></v-col>
+        </v-row>
+        <v-row class="row-vueflow">
+          <v-col><NodePlane /></v-col>
+        </v-row>
+        <v-row>
+          <v-col><MainBottom /></v-col>
+        </v-row>
       </v-container>
     </v-main>
   </v-app>
 </template>
+
+<style>
+@import './styles/main.css';
+</style>

--- a/src/components/MainBottom.vue
+++ b/src/components/MainBottom.vue
@@ -1,0 +1,23 @@
+<script setup>
+import VueCommand, { createStdout } from "vue-command";
+import "vue-command/dist/vue-command.css";
+const commands ={
+    "hello-world": () => createStdout("Hello world"),
+}
+let data_list = []
+</script>
+
+<template>
+        <vue-command 
+        class="cmd-size" 
+        :commands="commands" 
+        title="terraform log" 
+        is-fullscreen/>
+</template>
+<style>
+.cmd-size {
+    width: 100%;
+    height: 200px;
+}
+</style>
+  

--- a/src/components/MainTop.vue
+++ b/src/components/MainTop.vue
@@ -1,0 +1,13 @@
+<script setup>
+const region = "us-east-1"
+</script>
+
+<style>
+.top{margin:10px 0px 5px 5px;}
+</style>
+
+<template>
+    <v-sheet class="top text-center" elevation="3" max-width="10%" rounded>
+      <div class="text-body-2 text-black font-weight-bold">{{ region }}</div>
+    </v-sheet>
+</template>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -55,3 +55,6 @@ body,
 .row-vueflow {
   height: 80%;
 }
+.container-size {
+  height: 100%;
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -12,11 +12,9 @@ body,
 }
 
 #app {
-  text-transform: uppercase;
   font-family: 'JetBrains Mono', monospace;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  text-align: center;
   color: #2c3e50;
 }
 
@@ -25,10 +23,35 @@ body,
   transform-origin: bottom right;
 }
 
-.dndflow{flex-direction:column;display:flex;height:100%}.dndflow aside{color:#fff;font-weight:700;border-right:1px solid #eee;padding:15px 10px;font-size:12px;background:rgba(16,185,129,.75);-webkit-box-shadow:0px 5px 10px 0px rgba(0,0,0,.3);box-shadow:0 5px 10px #0000004d}.dndflow aside .nodes>*{margin-bottom:10px;cursor:grab;font-weight:500;-webkit-box-shadow:5px 5px 10px 2px rgba(0,0,0,.25);box-shadow:5px 5px 10px 2px #00000040}.dndflow aside .description{margin-bottom:10px}.dndflow .vue-flow-wrapper{flex-grow:1;height:100%}@media screen and (min-width: 640px){.dndflow{flex-direction:row}.dndflow aside{min-width:25%}}@media screen and (max-width: 639px){.dndflow aside .nodes{display:flex;flex-direction:row;gap:5px}}
+.dndflow{flex-direction:column;display:flex;height:100%}
+.dndflow aside{color:#fff;font-weight:700;border-right:1px solid #eee;padding:15px 10px;font-size:12px;background:rgba(16,185,129,.75);-webkit-box-shadow:0px 5px 10px 0px rgba(0,0,0,.3);box-shadow:0 5px 10px #0000004d}
+.dndflow aside .nodes>*{margin-bottom:10px;cursor:grab;font-weight:500;-webkit-box-shadow:5px 5px 10px 2px rgba(0,0,0,.25);box-shadow:5px 5px 10px 2px #00000040}
+.dndflow aside .description{margin-bottom:10px}
+.dndflow .vue-flow-wrapper{flex-grow:1;height:100%}@media screen and (min-width: 640px){.dndflow{flex-direction:row}
+.dndflow aside{min-width:25%}}@media screen and (max-width: 639px){.dndflow aside .nodes{display:flex;flex-direction:row;gap:5px}}
 
-.customnodeflow .vue-flow__node-exam1{border:1px solid #777;padding:10px;border-radius:10px;background:whitesmoke;display:flex;flex-direction:column;justify-content:space-between;align-items:center;gap:10px;max-width:250px}.customnodeflow button{padding:5px;width:25px;height:25px;border-radius:25px;-webkit-box-shadow:0px 5px 10px 0px rgba(0,0,0,.3);box-shadow:0 5px 10px #0000004d;cursor:pointer}.customnodeflow button:hover{opacity:.9;transform:scale(105%);transition:.25s all ease}.animated-bg-gradient{background:linear-gradient(122deg,#6f3381,#81c7d4,#fedfe1,#fffffb);background-size:800% 800%;-webkit-animation:gradient 4s ease infinite;-moz-animation:gradient 4s ease infinite;animation:gradient 4s ease infinite}@-webkit-keyframes gradient{0%{background-position:0% 22%}50%{background-position:100% 79%}to{background-position:0% 22%}}@-moz-keyframes gradient{0%{background-position:0% 22%}50%{background-position:100% 79%}to{background-position:0% 22%}}@keyframes gradient{0%{background-position:0% 22%}50%{background-position:100% 79%}to{background-position:0% 22%}}
-.customnodeflow .vue-flow__node-parent{border:1px solid #777;padding:10px;border-radius:10px;background:whitesmoke;display:flex;flex-direction:column;justify-content:space-between;align-items:center;gap:10px;}.customnodeflow button{padding:5px;width:25px;height:25px;border-radius:25px;-webkit-box-shadow:0px 5px 10px 0px rgba(0,0,0,.3);box-shadow:0 5px 10px #0000004d;cursor:pointer}.customnodeflow button:hover{opacity:.9;transform:scale(105%);transition:.25s all ease}.animated-bg-gradient{background:linear-gradient(122deg,#6f3381,#81c7d4,#fedfe1,#fffffb);background-size:800% 800%;-webkit-animation:gradient 4s ease infinite;-moz-animation:gradient 4s ease infinite;animation:gradient 4s ease infinite}@-webkit-keyframes gradient{0%{background-position:0% 22%}50%{background-position:100% 79%}to{background-position:0% 22%}}@-moz-keyframes gradient{0%{background-position:0% 22%}50%{background-position:100% 79%}to{background-position:0% 22%}}@keyframes gradient{0%{background-position:0% 22%}50%{background-position:100% 79%}to{background-position:0% 22%}}
-.customnodeflow .vue-flow__node-child{border:1px solid #777;padding:10px;border-radius:10px;background:whitesmoke;display:flex;flex-direction:column;justify-content:space-between;align-items:center;gap:10px;max-width:250px}.customnodeflow button{padding:5px;width:25px;height:25px;border-radius:25px;-webkit-box-shadow:0px 5px 10px 0px rgba(0,0,0,.3);box-shadow:0 5px 10px #0000004d;cursor:pointer}.customnodeflow button:hover{opacity:.9;transform:scale(105%);transition:.25s all ease}.animated-bg-gradient{background:linear-gradient(122deg,#6f3381,#81c7d4,#fedfe1,#fffffb);background-size:800% 800%;-webkit-animation:gradient 4s ease infinite;-moz-animation:gradient 4s ease infinite;animation:gradient 4s ease infinite}@-webkit-keyframes gradient{0%{background-position:0% 22%}50%{background-position:100% 79%}to{background-position:0% 22%}}@-moz-keyframes gradient{0%{background-position:0% 22%}50%{background-position:100% 79%}to{background-position:0% 22%}}@keyframes gradient{0%{background-position:0% 22%}50%{background-position:100% 79%}to{background-position:0% 22%}}
+.customnodeflow .vue-flow__node-exam1{border:1px solid #777;padding:10px;border-radius:10px;background:whitesmoke;display:flex;flex-direction:column;justify-content:space-between;align-items:center;gap:10px;max-width:250px}
+.customnodeflow button{padding:5px;width:25px;height:25px;border-radius:25px;-webkit-box-shadow:0px 5px 10px 0px rgba(0,0,0,.3);box-shadow:0 5px 10px #0000004d;cursor:pointer}
+.customnodeflow button:hover{opacity:.9;transform:scale(105%);transition:.25s all ease}
+.animated-bg-gradient{background:linear-gradient(122deg,#6f3381,#81c7d4,#fedfe1,#fffffb);background-size:800% 800%;-webkit-animation:gradient 4s ease infinite;-moz-animation:gradient 4s ease infinite;animation:gradient 4s ease infinite}@-webkit-keyframes gradient{0%{background-position:0% 22%}50%{background-position:100% 79%}to{background-position:0% 22%}}@-moz-keyframes gradient{0%{background-position:0% 22%}50%{background-position:100% 79%}to{background-position:0% 22%}}@keyframes gradient{0%{background-position:0% 22%}50%{background-position:100% 79%}to{background-position:0% 22%}}
+.customnodeflow .vue-flow__node-parent{border:1px solid #777;padding:10px;border-radius:10px;background:whitesmoke;display:flex;flex-direction:column;justify-content:space-between;align-items:center;gap:10px;}
+.customnodeflow button{padding:5px;width:25px;height:25px;border-radius:25px;-webkit-box-shadow:0px 5px 10px 0px rgba(0,0,0,.3);box-shadow:0 5px 10px #0000004d;cursor:pointer}
+.customnodeflow button:hover{opacity:.9;transform:scale(105%);transition:.25s all ease}
+.animated-bg-gradient{background:linear-gradient(122deg,#6f3381,#81c7d4,#fedfe1,#fffffb);background-size:800% 800%;-webkit-animation:gradient 4s ease infinite;-moz-animation:gradient 4s ease infinite;animation:gradient 4s ease infinite}@-webkit-keyframes gradient{0%{background-position:0% 22%}50%{background-position:100% 79%}to{background-position:0% 22%}}@-moz-keyframes gradient{0%{background-position:0% 22%}50%{background-position:100% 79%}to{background-position:0% 22%}}@keyframes gradient{0%{background-position:0% 22%}50%{background-position:100% 79%}to{background-position:0% 22%}}
+.customnodeflow .vue-flow__node-child{border:1px solid #777;padding:10px;border-radius:10px;background:whitesmoke;display:flex;flex-direction:column;justify-content:space-between;align-items:center;gap:10px;max-width:250px}
+.customnodeflow button{padding:5px;width:25px;height:25px;border-radius:25px;-webkit-box-shadow:0px 5px 10px 0px rgba(0,0,0,.3);box-shadow:0 5px 10px #0000004d;cursor:pointer}
+.customnodeflow button:hover{opacity:.9;transform:scale(105%);transition:.25s all ease}
+.animated-bg-gradient{background:linear-gradient(122deg,#6f3381,#81c7d4,#fedfe1,#fffffb);background-size:800% 800%;-webkit-animation:gradient 4s ease infinite;-moz-animation:gradient 4s ease infinite;animation:gradient 4s ease infinite}@-webkit-keyframes gradient{0%{background-position:0% 22%}50%{background-position:100% 79%}to{background-position:0% 22%}}@-moz-keyframes gradient{0%{background-position:0% 22%}50%{background-position:100% 79%}to{background-position:0% 22%}}@keyframes gradient{0%{background-position:0% 22%}50%{background-position:100% 79%}to{background-position:0% 22%}}
 
-.basicflow.dark{background:#57534e;color:#fffffb}.basicflow.dark .vue-flow__node{background:#292524;color:#fffffb}.basicflow.dark .vue-flow__controls .vue-flow__controls-button{background:#292524;fill:#fffffb;border-color:#fffffb}.basicflow.dark .vue-flow__edge-textbg{fill:#292524}.basicflow.dark .vue-flow__edge-text{fill:#fffffb}.basicflow .controls{display:flex;flex-wrap:wrap;justify-content:center;gap:8px}.basicflow .controls button{padding:4px;border-radius:5px;font-weight:600;-webkit-box-shadow:0px 5px 10px 0px rgba(0,0,0,.3);box-shadow:0 5px 10px #0000004d;cursor:pointer;display:flex;justify-content:center;align-items:center}.basicflow .controls button:hover{transform:scale(102%);transition:.25s all ease}
+.basicflow.dark{background:#57534e;color:#fffffb}
+.basicflow.dark .vue-flow__node{background:#292524;color:#fffffb}
+.basicflow.dark .vue-flow__controls .vue-flow__controls-button{background:#292524;fill:#fffffb;border-color:#fffffb}
+.basicflow.dark .vue-flow__edge-textbg{fill:#292524}
+.basicflow.dark .vue-flow__edge-text{fill:#fffffb}
+.basicflow .controls{display:flex;flex-wrap:wrap;justify-content:center;gap:8px}
+.basicflow .controls button{padding:4px;border-radius:5px;font-weight:600;-webkit-box-shadow:0px 5px 10px 0px rgba(0,0,0,.3);box-shadow:0 5px 10px #0000004d;cursor:pointer;display:flex;justify-content:center;align-items:center}
+.basicflow .controls button:hover{transform:scale(102%);transition:.25s all ease}
+
+.row-vueflow {
+  height: 80%;
+}


### PR DESCRIPTION
## Description

- [x] vuetify의 grid 시스템을 이용해서 메인보드 분할(container안에 row와 col로 감싸줬어요 ㅎㅎ)
- [x] 메인보드 상단의 리전 표시 추가(추후 값을 동적으로 할당할 수 있도록 수정 필요)
- [x] 메인보드 하단의 테라폼 로그를 위한 터미널 ui 추가

참고용 대시보드에요~
<img width="1253" alt="image" src="https://github.com/Terraform-Canvas/front-end/assets/42088290/4a94a068-074d-430f-ae5a-78723bf2814f">

## Related Issue

close #8 
