### PR TITLE
[수정] node 상태 관리 변경 및 rightdrawer 확인 추가

### DIFF
--- a/src/components/aws/DrawerInput.vue
+++ b/src/components/aws/DrawerInput.vue
@@ -58,6 +58,16 @@ onBeforeUpdate(() => {
     <div v-else-if="nodeType == 'alb'">
         <v-card class="mx-auto">
             <v-container>
+                <v-row class="text-right">
+                    <v-col>
+                        <v-icon
+                            class="close-btn"
+                            v-bind="props"
+                            @click="closeForm"
+                            >mdi-close</v-icon
+                        >
+                    </v-col>
+                </v-row>
                 <v-row class="drawer-header" align="center">
                     <div class="drawer-header-logo">
                         <v-img src="@/assets/resources/aws/alb.png" />
@@ -67,7 +77,7 @@ onBeforeUpdate(() => {
                 <v-row>
                     <v-col class="text-right">
                         <v-btn class="save-btn" @click="saveForm">Save</v-btn>
-                        <v-btn class="close-btn" @click="closeForm"
+                        <v-btn class="cancel-btn" @click="closeForm"
                             >Close</v-btn
                         >
                     </v-col>
@@ -78,6 +88,16 @@ onBeforeUpdate(() => {
     <div v-else-if="nodeType == 'asg'">
         <v-card class="mx-auto">
             <v-container>
+                <v-row class="text-right">
+                    <v-col>
+                        <v-icon
+                            class="close-btn"
+                            v-bind="props"
+                            @click="closeForm"
+                            >mdi-close</v-icon
+                        >
+                    </v-col>
+                </v-row>
                 <div class="drawer-header-logo">
                     <v-img src="@/assets/resources/aws/asg.png" />
                 </div>
@@ -149,7 +169,7 @@ onBeforeUpdate(() => {
                 <v-row>
                     <v-col class="text-right">
                         <v-btn class="save-btn" @click="saveForm">Save</v-btn>
-                        <v-btn class="close-btn" @click="closeForm"
+                        <v-btn class="cancel-btn" @click="closeForm"
                             >Close</v-btn
                         >
                     </v-col>
@@ -160,6 +180,16 @@ onBeforeUpdate(() => {
     <div v-else-if="nodeType == 'ec2'">
         <v-card class="mx-auto">
             <v-container>
+                <v-row class="text-right">
+                    <v-col>
+                        <v-icon
+                            class="close-btn"
+                            v-bind="props"
+                            @click="closeForm"
+                            >mdi-close</v-icon
+                        >
+                    </v-col>
+                </v-row>
                 <v-row class="drawer-header" align="center">
                     <div class="drawer-header-logo">
                         <v-img src="@/assets/resources/aws/ec2.png" />
@@ -177,7 +207,7 @@ onBeforeUpdate(() => {
                 <v-row>
                     <v-col class="text-right">
                         <v-btn class="save-btn" @click="saveForm">Save</v-btn>
-                        <v-btn class="close-btn" @click="closeForm"
+                        <v-btn class="cancel-btn" @click="closeForm"
                             >Close</v-btn
                         >
                     </v-col>
@@ -188,6 +218,16 @@ onBeforeUpdate(() => {
     <div v-else-if="nodeType == 'natgw'">
         <v-card class="mx-auto">
             <v-container>
+                <v-row class="text-right">
+                    <v-col>
+                        <v-icon
+                            class="close-btn"
+                            v-bind="props"
+                            @click="closeForm"
+                            >mdi-close</v-icon
+                        >
+                    </v-col>
+                </v-row>
                 <v-row class="drawer-header" align="center">
                     <div class="drawer-header-logo">
                         <v-img src="@/assets/resources/aws/alb.png" />
@@ -197,7 +237,7 @@ onBeforeUpdate(() => {
                 <v-row>
                     <v-col class="text-right">
                         <v-btn class="save-btn" @click="saveForm">Save</v-btn>
-                        <v-btn class="close-btn" @click="closeForm"
+                        <v-btn class="cancel-btn" @click="closeForm"
                             >Close</v-btn
                         >
                     </v-col>
@@ -208,13 +248,23 @@ onBeforeUpdate(() => {
     <div v-else-if="nodeType == 'privatesubnet'">
         <v-card class="mx-auto">
             <v-container>
+                <v-row class="text-right">
+                    <v-col>
+                        <v-icon
+                            class="close-btn"
+                            v-bind="props"
+                            @click="closeForm"
+                            >mdi-close</v-icon
+                        >
+                    </v-col>
+                </v-row>
                 <v-row class="drawer-header" align="center">
                     <div class="drawer-header-title">Private Subnet</div>
                 </v-row>
                 <v-row>
                     <v-col class="text-right">
                         <v-btn class="save-btn" @click="saveForm">Save</v-btn>
-                        <v-btn class="close-btn" @click="closeForm"
+                        <v-btn class="cancel-btn" @click="closeForm"
                             >Close</v-btn
                         >
                     </v-col>
@@ -225,13 +275,23 @@ onBeforeUpdate(() => {
     <div v-else-if="nodeType == 'publicsubnet'">
         <v-card class="mx-auto">
             <v-container>
+                <v-row class="text-right">
+                    <v-col>
+                        <v-icon
+                            class="close-btn"
+                            v-bind="props"
+                            @click="closeForm"
+                            >mdi-close</v-icon
+                        >
+                    </v-col>
+                </v-row>
                 <v-row class="drawer-header" align="center">
                     <div class="drawer-header-title">Public Subnet</div>
                 </v-row>
                 <v-row>
                     <v-col class="text-right">
                         <v-btn class="save-btn" @click="saveForm">Save</v-btn>
-                        <v-btn class="close-btn" @click="closeForm"
+                        <v-btn class="cancel-btn" @click="closeForm"
                             >Close</v-btn
                         >
                     </v-col>
@@ -242,6 +302,16 @@ onBeforeUpdate(() => {
     <div v-else-if="nodeType == 'sg'">
         <v-card class="mx-auto">
             <v-container>
+                <v-row class="text-right">
+                    <v-col>
+                        <v-icon
+                            class="close-btn"
+                            v-bind="props"
+                            @click="closeForm"
+                            >mdi-close</v-icon
+                        >
+                    </v-col>
+                </v-row>
                 <v-row class="drawer-header" align="center">
                     <div class="drawer-header-title">Security Group</div>
                 </v-row>
@@ -255,7 +325,7 @@ onBeforeUpdate(() => {
                 <v-row>
                     <v-col class="text-right">
                         <v-btn class="save-btn" @click="saveForm">Save</v-btn>
-                        <v-btn class="close-btn" @click="closeForm"
+                        <v-btn class="cancel-btn" @click="closeForm"
                             >Close</v-btn
                         >
                     </v-col>
@@ -266,6 +336,16 @@ onBeforeUpdate(() => {
     <div v-else-if="nodeType == 'vpc'">
         <v-card class="mx-auto">
             <v-container>
+                <v-row class="text-right">
+                    <v-col>
+                        <v-icon
+                            class="close-btn"
+                            v-bind="props"
+                            @click="closeForm"
+                            >mdi-close</v-icon
+                        >
+                    </v-col>
+                </v-row>
                 <v-row class="drawer-header" align="center">
                     <div class="drawer-header-title">VPC</div>
                 </v-row>
@@ -300,7 +380,7 @@ onBeforeUpdate(() => {
                 <v-row>
                     <v-col class="text-right">
                         <v-btn class="save-btn" @click="saveForm">Save</v-btn>
-                        <v-btn class="close-btn" @click="closeForm"
+                        <v-btn class="cancel-btn" @click="closeForm"
                             >Close</v-btn
                         >
                     </v-col>
@@ -313,7 +393,6 @@ onBeforeUpdate(() => {
 <style>
 .drawer-header {
     padding-bottom: 3rem;
-    padding-top: 2rem;
 }
 
 .drawer-header-title {
@@ -327,7 +406,7 @@ onBeforeUpdate(() => {
     height: 4rem;
 }
 
-.close-btn {
+.cancel-btn {
     margin-left: auto;
     margin-right: 1rem;
     margin-bottom: 0.5rem;
@@ -344,5 +423,8 @@ onBeforeUpdate(() => {
     background-color: #404ae7;
     color: white;
     font-weight: bold;
+}
+
+.cancel-btn {
 }
 </style>

--- a/src/components/aws/DrawerInput.vue
+++ b/src/components/aws/DrawerInput.vue
@@ -1,11 +1,12 @@
 <script setup>
 import { ref } from 'vue';
-import { reactive, onBeforeUpdate, defineEmits } from 'vue';
+import { reactive, onBeforeUpdate, defineEmits, defineProps, watch } from 'vue';
 import store from '@/store';
 
 let instance_items = [];
 let currentNodeData = reactive({});
 const nodeType = ref('');
+const props = defineProps(['drawer']);
 
 store.dispatch('aws/getInstanceTypes').then((res) => {
     const instance_type = store.state.aws.instance_types;
@@ -20,11 +21,18 @@ const emit = defineEmits(['handleRightDrawer']);
 
 const saveForm = () => {
     store.dispatch('node/updateSelectedNodeData', currentNodeData);
-    currentNodeData = reactive({});
     emit('handleRightDrawer');
+    currentNodeData = reactive({});
+};
+
+const updateValue = (newTextValue, arg) => {
+    currentNodeData[arg] = newTextValue.target.value;
 };
 
 onBeforeUpdate(() => {
+    if (!props.drawer) {
+        currentNodeData = {};
+    }
     if (store.getters['node/getSelectedNode']) {
         currentNodeData = reactive({
             ...store.getters['node/getSelectedNode'].data,
@@ -62,25 +70,29 @@ onBeforeUpdate(() => {
                     <div class="drawer-header-title">Auto Scailing Group</div>
                 </v-row>
                 <v-text-field
-                    v-model="currentNodeData.min_size"
+                    :model-value="currentNodeData.min_size"
+                    @input="updateValue($event, 'min_size')"
                     color="primary"
                     label="Min Size"
                     variant="underlined"
                 />
                 <v-text-field
-                    v-model="currentNodeData.max_size"
+                    :model-value="currentNodeData.max_size"
+                    @input="updateValue($event, 'max_size')"
                     color="primary"
                     label="Max Size"
                     variant="underlined"
                 />
                 <v-text-field
-                    v-model="currentNodeData.desired_capacity"
+                    :model-value="currentNodeData.desired_capacity"
+                    @input="updateValue($event, 'desired_capacity')"
                     color="primary"
                     label="Desired Capacity"
                     variant="underlined"
                 ></v-text-field>
                 <v-combobox
-                    v-model="currentNodeData.image_id"
+                    :model-value="currentNodeData.image_id"
+                    @input="updateValue($event, 'image_id')"
                     :items="store.state.aws.ami"
                     item-title="ImageId"
                     item-value="ImageId"
@@ -102,7 +114,8 @@ onBeforeUpdate(() => {
                     </template>
                 </v-combobox>
                 <v-combobox
-                    v-model="currentNodeData.instance_type"
+                    :model-value="currentNodeData.instance_type"
+                    @input="updateValue($event, 'instance_type')"
                     :items="instance_items"
                     color="primary"
                     label="Instance Type"
@@ -113,7 +126,8 @@ onBeforeUpdate(() => {
                     variant="underlined"
                     clear-icon="mdi-close-circle"
                     label="user-data"
-                    v-model="currentNodeData.user_data"
+                    :model-value="currentNodeData.user_data"
+                    @input="updateValue($event, 'user_data')"
                 >
                 </v-textarea>
 
@@ -135,7 +149,8 @@ onBeforeUpdate(() => {
                     <div class="drawer-header-title">EC2</div>
                 </v-row>
                 <v-combobox
-                    v-model="currentNodeData.instance_type"
+                    :model-value="currentNodeData.instance_type"
+                    @input="updateValue($event, 'instance_type')"
                     :items="instance_items"
                     color="primary"
                     label="Instance Type"
@@ -201,7 +216,8 @@ onBeforeUpdate(() => {
                     <div class="drawer-header-title">Security Group</div>
                 </v-row>
                 <v-text-field
-                    v-model="currentNodeData.name"
+                    :model-value="currentNodeData.name"
+                    @input="updateValue($event, 'name')"
                     color="primary"
                     label="Name"
                     variant="underlined"
@@ -221,25 +237,29 @@ onBeforeUpdate(() => {
                     <div class="drawer-header-title">VPC</div>
                 </v-row>
                 <v-text-field
-                    v-model="currentNodeData.name"
+                    :model-value="currentNodeData.name"
+                    @input="updateValue($event, 'name')"
                     color="primary"
                     label="Name"
                     variant="underlined"
                 ></v-text-field>
                 <v-text-field
-                    v-model="currentNodeData.cidr"
+                    :model-value="currentNodeData.cidr"
+                    @input="updateValue($event, 'cidr')"
                     color="primary"
                     label="CIDR"
                     variant="underlined"
                 ></v-text-field>
                 <v-text-field
-                    v-model="currentNodeData.public_subnet"
+                    :model-value="currentNodeData.public_subnet"
+                    @input="updateValue($event, 'public_subnet')"
                     color="primary"
                     label="Public Subnet"
                     variant="underlined"
                 ></v-text-field>
                 <v-text-field
-                    v-model="currentNodeData.private_subnet"
+                    :model-value="currentNodeData.private_subnet"
+                    @input="updateValue($event, 'private_subnet')"
                     color="primary"
                     label="Private Subnet"
                     variant="underlined"

--- a/src/components/aws/DrawerInput.vue
+++ b/src/components/aws/DrawerInput.vue
@@ -76,10 +76,10 @@ onBeforeUpdate(() => {
                 </v-row>
                 <v-row>
                     <v-col class="text-right">
-                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
                         <v-btn class="cancel-btn" @click="closeForm"
                             >Close</v-btn
                         >
+                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
                     </v-col>
                 </v-row>
             </v-container>
@@ -168,10 +168,10 @@ onBeforeUpdate(() => {
 
                 <v-row>
                     <v-col class="text-right">
-                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
                         <v-btn class="cancel-btn" @click="closeForm"
                             >Close</v-btn
                         >
+                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
                     </v-col>
                 </v-row>
             </v-container>
@@ -206,10 +206,10 @@ onBeforeUpdate(() => {
                 />
                 <v-row>
                     <v-col class="text-right">
-                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
                         <v-btn class="cancel-btn" @click="closeForm"
                             >Close</v-btn
                         >
+                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
                     </v-col>
                 </v-row>
             </v-container>
@@ -236,10 +236,10 @@ onBeforeUpdate(() => {
                 </v-row>
                 <v-row>
                     <v-col class="text-right">
-                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
                         <v-btn class="cancel-btn" @click="closeForm"
                             >Close</v-btn
                         >
+                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
                     </v-col>
                 </v-row>
             </v-container>
@@ -263,10 +263,10 @@ onBeforeUpdate(() => {
                 </v-row>
                 <v-row>
                     <v-col class="text-right">
-                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
                         <v-btn class="cancel-btn" @click="closeForm"
                             >Close</v-btn
                         >
+                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
                     </v-col>
                 </v-row>
             </v-container>
@@ -290,10 +290,10 @@ onBeforeUpdate(() => {
                 </v-row>
                 <v-row>
                     <v-col class="text-right">
-                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
                         <v-btn class="cancel-btn" @click="closeForm"
                             >Close</v-btn
                         >
+                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
                     </v-col>
                 </v-row>
             </v-container>
@@ -324,10 +324,10 @@ onBeforeUpdate(() => {
                 ></v-text-field>
                 <v-row>
                     <v-col class="text-right">
-                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
                         <v-btn class="cancel-btn" @click="closeForm"
                             >Close</v-btn
                         >
+                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
                     </v-col>
                 </v-row>
             </v-container>
@@ -379,10 +379,10 @@ onBeforeUpdate(() => {
                 ></v-text-field>
                 <v-row>
                     <v-col class="text-right">
-                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
                         <v-btn class="cancel-btn" @click="closeForm"
                             >Close</v-btn
                         >
+                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
                     </v-col>
                 </v-row>
             </v-container>

--- a/src/components/aws/DrawerInput.vue
+++ b/src/components/aws/DrawerInput.vue
@@ -21,18 +21,28 @@ const emit = defineEmits(['handleRightDrawer']);
 
 const saveForm = () => {
     store.dispatch('node/updateSelectedNodeData', currentNodeData);
-    emit('handleRightDrawer');
     currentNodeData = reactive({});
+    emit('handleRightDrawer');
 };
 
+const closeForm = () => {
+    currentNodeData = reactive({});
+    emit('handleRightDrawer');
+};
 const updateValue = (newTextValue, arg) => {
     currentNodeData[arg] = newTextValue.target.value;
 };
+watch(
+    () => props.drawer, // For init input form
+    (newValue, oldValue) => {
+        if (!newValue) {
+            currentNodeData = reactive({});
+            nodeType.value = null;
+        }
+    },
+);
 
 onBeforeUpdate(() => {
-    if (!props.drawer) {
-        currentNodeData = {};
-    }
     if (store.getters['node/getSelectedNode']) {
         currentNodeData = reactive({
             ...store.getters['node/getSelectedNode'].data,
@@ -43,7 +53,9 @@ onBeforeUpdate(() => {
 </script>
 
 <template>
-    <div v-if="nodeType == 'alb'">
+    <!--Trick Component for rerendering -->
+    <div v-if="!nodeType"></div>
+    <div v-else-if="nodeType == 'alb'">
         <v-card class="mx-auto">
             <v-container>
                 <v-row class="drawer-header" align="center">
@@ -55,6 +67,9 @@ onBeforeUpdate(() => {
                 <v-row>
                     <v-col class="text-right">
                         <v-btn class="save-btn" @click="saveForm">Save</v-btn>
+                        <v-btn class="close-btn" @click="closeForm"
+                            >Close</v-btn
+                        >
                     </v-col>
                 </v-row>
             </v-container>
@@ -134,6 +149,9 @@ onBeforeUpdate(() => {
                 <v-row>
                     <v-col class="text-right">
                         <v-btn class="save-btn" @click="saveForm">Save</v-btn>
+                        <v-btn class="close-btn" @click="closeForm"
+                            >Close</v-btn
+                        >
                     </v-col>
                 </v-row>
             </v-container>
@@ -159,6 +177,9 @@ onBeforeUpdate(() => {
                 <v-row>
                     <v-col class="text-right">
                         <v-btn class="save-btn" @click="saveForm">Save</v-btn>
+                        <v-btn class="close-btn" @click="closeForm"
+                            >Close</v-btn
+                        >
                     </v-col>
                 </v-row>
             </v-container>
@@ -176,6 +197,9 @@ onBeforeUpdate(() => {
                 <v-row>
                     <v-col class="text-right">
                         <v-btn class="save-btn" @click="saveForm">Save</v-btn>
+                        <v-btn class="close-btn" @click="closeForm"
+                            >Close</v-btn
+                        >
                     </v-col>
                 </v-row>
             </v-container>
@@ -190,6 +214,9 @@ onBeforeUpdate(() => {
                 <v-row>
                     <v-col class="text-right">
                         <v-btn class="save-btn" @click="saveForm">Save</v-btn>
+                        <v-btn class="close-btn" @click="closeForm"
+                            >Close</v-btn
+                        >
                     </v-col>
                 </v-row>
             </v-container>
@@ -204,6 +231,9 @@ onBeforeUpdate(() => {
                 <v-row>
                     <v-col class="text-right">
                         <v-btn class="save-btn" @click="saveForm">Save</v-btn>
+                        <v-btn class="close-btn" @click="closeForm"
+                            >Close</v-btn
+                        >
                     </v-col>
                 </v-row>
             </v-container>
@@ -225,6 +255,9 @@ onBeforeUpdate(() => {
                 <v-row>
                     <v-col class="text-right">
                         <v-btn class="save-btn" @click="saveForm">Save</v-btn>
+                        <v-btn class="close-btn" @click="closeForm"
+                            >Close</v-btn
+                        >
                     </v-col>
                 </v-row>
             </v-container>
@@ -267,6 +300,9 @@ onBeforeUpdate(() => {
                 <v-row>
                     <v-col class="text-right">
                         <v-btn class="save-btn" @click="saveForm">Save</v-btn>
+                        <v-btn class="close-btn" @click="closeForm"
+                            >Close</v-btn
+                        >
                     </v-col>
                 </v-row>
             </v-container>
@@ -291,6 +327,15 @@ onBeforeUpdate(() => {
     height: 4rem;
 }
 
+.close-btn {
+    margin-left: auto;
+    margin-right: 1rem;
+    margin-bottom: 0.5rem;
+    height: 2rem;
+    background-color: #fa5252;
+    color: white;
+    font-weight: bold;
+}
 .save-btn {
     margin-left: auto;
     margin-right: 1rem;

--- a/src/components/aws/DrawerInput.vue
+++ b/src/components/aws/DrawerInput.vue
@@ -108,6 +108,15 @@ onBeforeUpdate(() => {
                     label="Instance Type"
                     variant="underlined"
                 />
+                <v-textarea
+                    clearable
+                    variant="underlined"
+                    clear-icon="mdi-close-circle"
+                    label="user-data"
+                    v-model="currentNodeData.user_data"
+                >
+                </v-textarea>
+
                 <v-row>
                     <v-col class="text-right">
                         <v-btn class="save-btn" @click="saveForm">Save</v-btn>

--- a/src/components/aws/DrawerInput.vue
+++ b/src/components/aws/DrawerInput.vue
@@ -44,10 +44,12 @@ onBeforeUpdate(() => {
                     </div>
                     <div class="drawer-header-title">AWS Load Balancer</div>
                 </v-row>
+                <v-row>
+                    <v-col class="text-right">
+                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
+                    </v-col>
+                </v-row>
             </v-container>
-            <v-col class="text-right">
-                <v-btn class="save-btn" @click="saveForm">Save</v-btn>
-            </v-col>
         </v-card>
     </div>
     <div v-else-if="nodeType == 'asg'">
@@ -106,10 +108,12 @@ onBeforeUpdate(() => {
                     label="Instance Type"
                     variant="underlined"
                 />
+                <v-row>
+                    <v-col class="text-right">
+                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
+                    </v-col>
+                </v-row>
             </v-container>
-            <v-col class="text-right">
-                <v-btn class="save-btn" @click="saveForm">Save</v-btn>
-            </v-col>
         </v-card>
     </div>
     <div v-else-if="nodeType == 'ec2'">
@@ -128,10 +132,12 @@ onBeforeUpdate(() => {
                     label="Instance Type"
                     variant="underlined"
                 />
+                <v-row>
+                    <v-col class="text-right">
+                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
+                    </v-col>
+                </v-row>
             </v-container>
-            <v-col class="text-right">
-                <v-btn class="save-btn" @click="saveForm">Save</v-btn>
-            </v-col>
         </v-card>
     </div>
     <div v-else-if="nodeType == 'natgw'">
@@ -143,10 +149,12 @@ onBeforeUpdate(() => {
                     </div>
                     <div class="drawer-header-title">Nat Gateway</div>
                 </v-row>
+                <v-row>
+                    <v-col class="text-right">
+                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
+                    </v-col>
+                </v-row>
             </v-container>
-            <v-col class="text-right">
-                <v-btn class="save-btn" @click="saveForm">Save</v-btn>
-            </v-col>
         </v-card>
     </div>
     <div v-else-if="nodeType == 'privatesubnet'">
@@ -155,10 +163,12 @@ onBeforeUpdate(() => {
                 <v-row class="drawer-header" align="center">
                     <div class="drawer-header-title">Private Subnet</div>
                 </v-row>
+                <v-row>
+                    <v-col class="text-right">
+                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
+                    </v-col>
+                </v-row>
             </v-container>
-            <v-col class="text-right">
-                <v-btn class="save-btn" @click="saveForm">Save</v-btn>
-            </v-col>
         </v-card>
     </div>
     <div v-else-if="nodeType == 'publicsubnet'">
@@ -167,10 +177,12 @@ onBeforeUpdate(() => {
                 <v-row class="drawer-header" align="center">
                     <div class="drawer-header-title">Public Subnet</div>
                 </v-row>
+                <v-row>
+                    <v-col class="text-right">
+                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
+                    </v-col>
+                </v-row>
             </v-container>
-            <v-col class="text-right">
-                <v-btn class="save-btn" @click="saveForm">Save</v-btn>
-            </v-col>
         </v-card>
     </div>
     <div v-else-if="nodeType == 'sg'">
@@ -185,10 +197,12 @@ onBeforeUpdate(() => {
                     label="Name"
                     variant="underlined"
                 ></v-text-field>
+                <v-row>
+                    <v-col class="text-right">
+                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
+                    </v-col>
+                </v-row>
             </v-container>
-            <v-col class="text-right">
-                <v-btn class="save-btn" @click="saveForm">Save</v-btn>
-            </v-col>
         </v-card>
     </div>
     <div v-else-if="nodeType == 'vpc'">
@@ -221,10 +235,12 @@ onBeforeUpdate(() => {
                     label="Private Subnet"
                     variant="underlined"
                 ></v-text-field>
+                <v-row>
+                    <v-col class="text-right">
+                        <v-btn class="save-btn" @click="saveForm">Save</v-btn>
+                    </v-col>
+                </v-row>
             </v-container>
-            <v-col class="text-right">
-                <v-btn class="save-btn" @click="saveForm">Save</v-btn>
-            </v-col>
         </v-card>
     </div>
 </template>
@@ -248,6 +264,8 @@ onBeforeUpdate(() => {
 
 .save-btn {
     margin-left: auto;
+    margin-right: 1rem;
+    margin-bottom: 0.5rem;
     height: 2rem;
     background-color: #404ae7;
     color: white;

--- a/src/components/node/NodePlane.vue
+++ b/src/components/node/NodePlane.vue
@@ -21,6 +21,7 @@ import { ref } from 'vue';
 import MainTopVue from '../dashboard/MainTop.vue';
 
 import axios from '@/plugins/axios';
+import store from '@/store';
 let id = 0;
 function getId() {
     return `${id++}`;
@@ -47,9 +48,7 @@ const {
 
 onNodeClick((MouseEvent) => {
     nodeClicked();
-    getSelectedNodes.value.forEach((v) =>
-        console.log(`Selected: ${v.id}, type: ${v.type}`),
-    );
+    store.dispatch('node/setSelectedNode', getSelectedNodes.value[0]);
 });
 
 function onDragOver(event) {
@@ -102,12 +101,12 @@ function onDrop(event) {
 const showModal = ref(false);
 const exportData = ref('');
 let btnData = ref('create');
-let bntLoader = ref(false);
+let btnLoader = ref(false);
 let btnType = ref('');
 let btnMsg = ref('');
 const exportAndOpenModal = () => {
     let exportDataArr = [];
-    bntLoader.value = true;
+    btnLoader.value = true;
     getNodes.value.forEach((n) => {
         let nodeData = {
             id: n.id,
@@ -126,12 +125,12 @@ const exportAndOpenModal = () => {
                 btnData.value = 'run';
                 btnType.value = 'success';
                 btnMsg.value = 'tf 생성 완료';
-                bntLoader.value = false;
+                btnLoader.value = false;
             })
             .catch((err) => {
                 btnMsg.value = 'tf 생성 실패';
                 btnType.value = 'warning';
-                bntLoader.value = false;
+                btnLoader.value = false;
                 console.error(err);
             });
     } else if (btnData.value === 'run') {
@@ -141,12 +140,12 @@ const exportAndOpenModal = () => {
                 btnData.value = 'create';
                 btnMsg.value = 'tf 실행 완료';
                 btnType.value = 'success';
-                bntLoader.value = false;
+                btnLoader.value = false;
             })
             .catch((err) => {
                 btnMsg.value = 'tf 실행 실패';
                 btnType.value = 'warning';
-                bntLoader.value = false;
+                btnLoader.value = false;
                 console.error(err);
             });
     }
@@ -162,7 +161,7 @@ const exportAndOpenModal = () => {
     <div class="header-utils">
         <MainTopVue />
         <v-btn
-            :loading="bntLoader"
+            :loading="btnLoader"
             class="export-btn"
             @click="exportAndOpenModal"
             >{{ btnData }}</v-btn

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,10 +2,12 @@ import { createStore } from 'vuex';
 import login from '@/store/modules/login';
 import user from '@/store/modules/user';
 import aws from '@/store/modules/aws';
+import node from '@/store/modules/node';
 export default createStore({
     modules: {
         login,
         user,
         aws,
+        node,
     },
 });

--- a/src/store/modules/node.js
+++ b/src/store/modules/node.js
@@ -1,0 +1,42 @@
+const state = () => ({
+    selectedNode: null,
+});
+
+const getters = {
+    getSelectedNode: function (state) {
+        return state.selectedNode;
+    },
+};
+
+const actions = {
+    setSelectedNode: function ({ commit }, node) {
+        commit('SET_SELECTED_NODE', node);
+    },
+    updateSelectedNodeData: function ({ commit }, payload) {
+        commit('UPDATE_SELECTED_NODE_DATA', payload);
+    },
+    resetSelectedNode: function ({ commit }) {
+        commit('RESET_SELECTED_NODE');
+    },
+};
+
+const mutations = {
+    SET_SELECTED_NODE: function (state, node) {
+        state.selectedNode = node;
+    },
+    UPDATE_SELECTED_NODE_DATA: function (state, payload) {
+        //vue에서 기본적으로 depth 1까지의 watch를 지원하여, 값 업데이트는 .data까지 접근하여 사용
+        state.selectedNode.data = payload;
+    },
+    RESET_SELECTED_NODE: function (state) {
+        state.selectedNode = null;
+    },
+};
+
+export default {
+    namespaced: true,
+    state,
+    getters,
+    actions,
+    mutations,
+};

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -5,7 +5,11 @@
         width="500"
         temporary
     >
-        <DrawerInput :drawer="drawer" @handleRightDrawer="handleRightDrawer" />
+        <DrawerInput
+            :drawer="drawer"
+            v-click-outside="handleClickOutside"
+            @handleRightDrawer="handleRightDrawer"
+        />
     </v-navigation-drawer>
     <v-main>
         <v-container fluid class="container-size">
@@ -31,6 +35,12 @@ const drawer = ref(false);
 const handleRightDrawer = () => {
     drawer.value = !drawer.value;
     store.dispatch('node/resetSelectedNode');
+};
+
+const handleClickOutside = () => {
+    if (store.getters['node/getSelectedNode'] && !drawer.value) {
+        drawer.value = true;
+    }
 };
 </script>
 

--- a/src/views/dashboard/index.vue
+++ b/src/views/dashboard/index.vue
@@ -5,7 +5,7 @@
         width="500"
         temporary
     >
-        <DrawerInput :selectedNode="selectedNode" />
+        <DrawerInput :drawer="drawer" @handleRightDrawer="handleRightDrawer" />
     </v-navigation-drawer>
     <v-main>
         <v-container fluid class="container-size">
@@ -20,19 +20,17 @@
 </template>
 
 <script setup>
-import MainTop from '@/components/dashboard/MainTop.vue';
 import NodePlane from '@/components/node/NodePlane';
 import MainBottom from '@/components/dashboard/MainBottom';
 import DrawerInput from '@/components/aws/DrawerInput.vue';
-import { ref, onUpdated } from 'vue';
+import { ref } from 'vue';
+import store from '@/store';
 
 const drawer = ref(false);
-const selectedNode = ref(Object);
-// v-navigation-drawer는 VueFlow 하위 컴포넌트가 아니라 Node를 찾을 수 없어 Object 통째로 넘겨줘야 함
 
-const handleRightDrawer = (selectedNodes) => {
+const handleRightDrawer = () => {
     drawer.value = !drawer.value;
-    selectedNode.value = selectedNodes.value[0];
+    store.dispatch('node/resetSelectedNode');
 };
 </script>
 


### PR DESCRIPTION
## Description
- save 버튼 추가
- node 관리를 위한 전역 상태 관리 (vuex) 도입
- 전역적인 상태 관리 flow 수정 및 개선 예정 (작성 중, https://www.figma.com/file/gJb91DLnfaabDhe5zy5a4G/Terraform-Canvas?type=whiteboard&node-id=0%3A1&t=MAsOo7CUizV5jNGn-1)
![image](https://github.com/Terraform-Canvas/front-end/assets/16442978/f85cbc54-5b0d-44ae-a664-e4ec368ac7e8)

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
close: #55 
close: #48 

<!-- If your PR refers to a related issue, link it here. -->
