### PR TITLE
[수정] 기존의 env 환경을 config로 대체

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,4 +11,5 @@ module.exports = {
         'no-unused-vars': 'off',
         'vue/multi-word-component-names': 'off',
     },
+    globals: { config_env: 'readable' },
 };

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,10 @@ jobs:
                 labels:
                   app: {{ include "terraform-canvas.name" . }}-front
               spec:
+                volumes:
+                  - name: config-volume
+                    configMap:
+                      name: fe-config
                 serviceAccountName: {{ include "terraform-canvas.serviceAccountName" . }}
                 containers:
                 - name: {{ .Chart.Name }}-front
@@ -72,13 +76,10 @@ jobs:
                   - name: http
                     containerPort: {{ .Values.frontend.lb.http.targetPort}}
                     protocol: TCP
-                  env:
-                      - name: VITE_BASE_URL
-                        valueFrom:
-                          secretKeyRef:
-                            name: back-config
-                            key: VITE_BASE_URL
-
+                  volumeMounts:
+                      - name: config-volume
+                        mountPath: /usr/share/nginx/html/config.js
+                        subPath: config.js
           ---
           apiVersion: v1
           kind: Service

--- a/config.js
+++ b/config.js
@@ -1,0 +1,5 @@
+const config_env = (() => {
+    return {
+        VUE_CONFIG_BASE_URL: 'http://localhost:8000/api/v1',
+    };
+})();

--- a/index.html
+++ b/index.html
@@ -10,5 +10,6 @@
     <body>
         <div id="app"></div>
         <script type="module" src="/src/main.js"></script>
+        <script src="./config.js"></script>
     </body>
 </html>

--- a/src/plugins/axios.js
+++ b/src/plugins/axios.js
@@ -16,7 +16,7 @@ axios.interceptors.request.use(
              * 기존 요청 정보에서 retry=true만 주가되고
              * 나머지는 그대로 다시 요청하기 때문에 url이 이상해져서 이렇게 나눔
              */
-            config.url = import.meta.env.VITE_BASE_URL + config.url; //host 및 url 방식 수정필요
+            config.url = config_env.VUE_CONFIG_BASE_URL + config.url; //host 및 url 방식 수정필요
         }
         //헤더 셋팅
         config.timeout = 20000;

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,6 @@ import vuetify, { transformAssetUrls } from 'vite-plugin-vuetify';
 // Utilities
 import { defineConfig } from 'vite';
 import { fileURLToPath, URL } from 'node:url';
-
 // https://vitejs.dev/config/
 export default defineConfig({
     plugins: [
@@ -30,4 +29,5 @@ export default defineConfig({
     server: {
         port: 3000,
     },
+    global: { config_env: 'readable' },
 });


### PR DESCRIPTION
## Description

- [x] 기존의 host url을 env로 써서 배포환경에서 secret으로 넘겨줬을 경우 인식이 안되는 문제 때문에 config로 수정

## Related Issue

Closes #63 
